### PR TITLE
add permissions for comments in pr pipeline workflows

### DIFF
--- a/workflow-templates/java-pr-pipeline.yml
+++ b/workflow-templates/java-pr-pipeline.yml
@@ -6,6 +6,8 @@ name: CI Pipeline - Pull Requests
 permissions:
   checks: write
   contents: read
+  issues: write
+  pull-requests: write
 
 on:
   workflow_dispatch:

--- a/workflow-templates/node-pr-pipeline.yml
+++ b/workflow-templates/node-pr-pipeline.yml
@@ -6,6 +6,8 @@ name: CI Pipeline - Pull Requests
 permissions:
   checks: write
   contents: read
+  issues: write
+  pull-requests: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
For functionality with https://github.com/brandwatch/bw-workflow-actions/pull/74 we need these permissions in order to find, edit, and create comments as per https://github.com/peter-evans/create-or-update-comment
