### PR TITLE
Add workflow for S3 Deploy

### DIFF
--- a/workflow-templates/cdn-deploy-pipeline.properties.json
+++ b/workflow-templates/cdn-deploy-pipeline.properties.json
@@ -1,0 +1,8 @@
+{
+    "name": "CDN Node Build Deploy",
+    "description": "This pipeline will deploy contents from the source folder into the Cloudfront CDN hosted on cdn.brandwatch.com. You may optionally build with NodeJS",
+    "iconName": "octicon package-dependents",
+    "categories": [
+        "deployment"
+    ]
+}

--- a/workflow-templates/cdn-deploy-pipeline.yml
+++ b/workflow-templates/cdn-deploy-pipeline.yml
@@ -1,0 +1,32 @@
+# For official documentation on this workflow, please refer to the link below.
+# https://github.com/brandwatch/bw-workflow-actions/blob/dev/workflows/cdn/cdn-deploy.yaml.md
+
+name: CI Pipeline - CDN Deploy
+
+permissions:
+  checks: write
+  contents: write
+  packages: read
+  id-token: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-pipeline:
+    name: "Build Pipeline"
+    uses: brandwatch/bw-workflow-actions/.github/workflows/cdn-deploy.yaml@production
+    with:
+      service-name: am-devp-cdn-test
+      content-version: ${{ github.sha }}
+      source-folder: static
+      dry-run: true # comment this line to make it the real deal
+
+# Node Build options
+#      build-step: true
+#      test: true
+#      linter: true
+#      node-version: 18
+    secrets: inherit


### PR DESCRIPTION
As title states. This new workflow is generic to any project, but will most likely be used as with the node build step. As such I have not included anything in the properties.json to force it to be tied with Javascript, since committing static files intended to be served is definitely not limited to projects which need to be built