### PR TITLE
Feat build and deploy docker image

### DIFF
--- a/workflow-templates/docker-build-deploy.json
+++ b/workflow-templates/docker-build-deploy.json
@@ -5,5 +5,8 @@
     "categories": [
         "deployment",
         "Docker"
+    ],
+    "filePatterns": [
+        "^Dockerfile"
     ]
 }

--- a/workflow-templates/docker-build-deploy.json
+++ b/workflow-templates/docker-build-deploy.json
@@ -1,0 +1,9 @@
+{
+    "name": "Custom Docker Build & Deploy",
+    "description": "This pipeline will take a Dockerfile and provides a build chain to push the image to Artifactory as well as deploying it to Janus whenever a new commit is pushed to the main branch",
+    "iconName": "octicon repo",
+    "categories": [
+        "deployment",
+        "Docker"
+    ]
+}

--- a/workflow-templates/docker-build-deploy.yml
+++ b/workflow-templates/docker-build-deploy.yml
@@ -1,0 +1,19 @@
+# For official documentation on this workflow, please refer to the link below.
+# https://github.com/brandwatch/bw-workflow-actions/blob/dev/workflows/docker/generic-docker-build-and-deploy.md
+
+name: CI Pipeline - Build & Deploy Custom Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  checks: write
+  contents: read
+
+jobs:
+  build-pipeline:
+    name: "Build & Deploy Docker Image"
+    uses: brandwatch/bw-workflow-actions/.github/workflows/generic-docker-build-and-deploy.yml@production
+    secrets: inherit

--- a/workflow-templates/docker-build-deploy.yml
+++ b/workflow-templates/docker-build-deploy.yml
@@ -1,7 +1,7 @@
 # For official documentation on this workflow, please refer to the link below.
 # https://github.com/brandwatch/bw-workflow-actions/blob/dev/workflows/docker/generic-docker-build-and-deploy.md
 
-name: CI Pipeline - Build & Deploy Custom Docker Image
+name: CI Pipeline - Custom Docker Image Build & Deploy
 
 on:
   push:


### PR DESCRIPTION
This is as per suggestion from [the following PR](https://github.com/brandwatch/bw-workflow-actions/pull/296#pullrequestreview-2620709920) to allow the workflow to be supplied when creating a new action in other repos. 