### PR TITLE
ci: add security-events & actions permissions to trivy workflows

### DIFF
--- a/workflow-templates/cdn-deploy-pipeline.yml
+++ b/workflow-templates/cdn-deploy-pipeline.yml
@@ -8,6 +8,8 @@ permissions:
   contents: write
   packages: read
   id-token: write
+  security-events: write
+  actions: read
 
 on:
   push:

--- a/workflow-templates/java-custom-image-build-pipeline.yml
+++ b/workflow-templates/java-custom-image-build-pipeline.yml
@@ -6,6 +6,8 @@ name: CI Pipeline - Build Custom Docker Image
 permissions:
   checks: write
   contents: read
+  security-events: write
+  actions: read
 
 on:
   push:

--- a/workflow-templates/java-image-build-pipeline.yml
+++ b/workflow-templates/java-image-build-pipeline.yml
@@ -6,6 +6,8 @@ name: CI Pipeline - Build Image
 permissions:
   checks: write
   contents: read
+  security-events: write
+  actions: read
 
 on:
   push:

--- a/workflow-templates/java-library-build-pipeline.yml
+++ b/workflow-templates/java-library-build-pipeline.yml
@@ -11,6 +11,8 @@ on:
 permissions:
   checks: write
   contents: write
+  security-events: write
+  actions: read
 
 jobs:
   build-pipeline:

--- a/workflow-templates/java-pr-pipeline.yml
+++ b/workflow-templates/java-pr-pipeline.yml
@@ -8,6 +8,8 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
+  security-events: write
+  actions: read
 
 on:
   workflow_dispatch:

--- a/workflow-templates/node-image-build-pipeline.yml
+++ b/workflow-templates/node-image-build-pipeline.yml
@@ -6,6 +6,8 @@ name: CI Pipeline - Build Image
 permissions:
   checks: write
   contents: read
+  security-events: write
+  actions: read
 
 on:
   push:

--- a/workflow-templates/node-multi-package-pipeline.yml
+++ b/workflow-templates/node-multi-package-pipeline.yml
@@ -7,6 +7,8 @@ permissions:
   checks: write
   contents: write
   packages: read
+  security-events: write
+  actions: read
 
 on:
   push:

--- a/workflow-templates/node-package-pipeline.yml
+++ b/workflow-templates/node-package-pipeline.yml
@@ -6,6 +6,8 @@ name: CI Pipeline - Publish Package
 permissions:
   checks: write
   contents: write
+  security-events: write
+  actions: read
 
 on:
   release:

--- a/workflow-templates/node-pr-pipeline.yml
+++ b/workflow-templates/node-pr-pipeline.yml
@@ -8,6 +8,8 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
+  security-events: write
+  actions: read
 
 on:
   workflow_dispatch:

--- a/workflow-templates/staticwebapp-node-built-pipeline.yml
+++ b/workflow-templates/staticwebapp-node-built-pipeline.yml
@@ -6,6 +6,8 @@ name: CI Pipeline - Build Using Node & Deploy Static Webapp
 permissions:
   checks: write
   contents: read
+  security-events: write
+  actions: read
 
 on:
   push:


### PR DESCRIPTION
I'm preparing the necessary workflows to seamlessly continue working for some breaking changes

Upcoming Trivy changes require these permissions to be set in the workflows that call it

Adding these permissions early should not cause any changes until the current stage branch on bw-workflow-actions is promoted to production. There will be comms before this happens. There is a confluence page with more details regarding what the changes will look like, along with suggested optional branch protection rules to use alongside them: https://brandwatch.atlassian.net/wiki/spaces/SRE/pages/4361453673/New+Trivy+SARIF+GitHub+Advanced+Security